### PR TITLE
Bump CDAP and Hadoop dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,13 +28,13 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spark.version>2.1.3</spark.version>
-    <cdap.version>6.1.1</cdap.version>
-    <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <cdap.version>6.8.0</cdap.version>
+    <hydrator.version>2.10.0</hydrator.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
-    <app.parents>system:cdap-data-pipeline[6.1.1,7.0.0-SNAPSHOT),system:cdap-data-streams[6.1.1,7.0.0-SNAPSHOT)</app.parents>
+    <app.parents>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT),system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</app.parents>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
   </properties>
@@ -80,7 +80,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
+      <artifactId>cdap-data-pipeline2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Bump CDAP version to 6.8, hydrator-plugins to 2.10.0, and hadoop to 2.10

Tested with unit tests.

Only remaining log4j dependency is in test scope:
```
[INFO] com.adaptivescale:google-search-console:jar:1.0.0-SNAPSHOT
[INFO] \- io.cdap.cdap:hydrator-test:jar:6.8.0:test
[INFO]    \- io.cdap.cdap:cdap-unit-test:jar:6.8.0:test
[INFO]       \- io.cdap.cdap:cdap-explore:jar:6.8.0:test
[INFO]          \- org.apache.hive:hive-metastore:jar:1.2.1:test
[INFO]             \- org.apache.hive:hive-serde:jar:1.2.1:test
[INFO]                \- org.apache.hive:hive-common:jar:1.2.1:test
[INFO]                   \- log4j:log4j:jar:1.2.16:test
```